### PR TITLE
Fixing nrcs soil moisture temperature regimes

### DIFF
--- a/2_SWSF_p4of4_Code_v51.R
+++ b/2_SWSF_p4of4_Code_v51.R
@@ -2047,14 +2047,15 @@ identify_soillayers <- function(depths, sdepth) {
   }
 }
 
-adjustLayer_byImp <- function(depths, imp_depth) {
-  if(any(imp_depth < depths[1])){
+adjustLayer_byImp <- function(depths, imp_depth, sdepths) {
+  if (any(imp_depth < depths[1])) {
     depths <- imp_depth
-    if(dim(soildat)[1] >= 2){
-      if((temp <- findInterval(imp_depth, soildat[, "depth_cm"])) > 1){
-        depths <- c(soildat[temp - 1, "depth_cm"], imp_depth)
+    if (length(sdepths) >= 2) {
+      temp <- findInterval(imp_depth, sdepths)
+      if (temp > 1) {
+        depths <- c(sdepths[temp - 1], imp_depth)
       } else {
-        depths <- c(imp_depth, soildat[temp + 1, "depth_cm"])
+        depths <- c(imp_depth, sdepths[temp + 1])
       }
     }
   } else if(any(imp_depth < depths[2])){
@@ -5374,10 +5375,10 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
               } else c(20, 60)
             #If 7.5 cm of water moistens the soil to a densic, lithic, paralithic, or petroferric contact or to a petrocalcic or petrogypsic horizon or a duripan, the contact or the upper boundary of the cemented horizon constitutes the lower boundary of the soil moisture control section. If a soil is moistened to one of these contacts or horizons by 2.5 cm of water, the soil moisture control section is the boundary of the contact itself. The control section of such a soil is considered moist if the contact or upper boundary of the cemented horizon has a thin film of water. If that upper boundary is dry, the control section is considered dry.
 
-            MCS_depth <- adjustLayer_byImp(depths = MCS_depth, imp_depth = imp_depth)
+            MCS_depth <- adjustLayer_byImp(depths = MCS_depth, imp_depth = imp_depth, sdepths = soildat[, "depth_cm"])
 
             #Soil layer 10-70 cm used for anhydrous layer definition; adjusted for impermeable layer
-            Lanh_depth <- adjustLayer_byImp(depths = c(10, 70), imp_depth = imp_depth)
+            Lanh_depth <- adjustLayer_byImp(depths = c(10, 70), imp_depth = imp_depth, sdepths = soildat[, "depth_cm"])
 
             #Permafrost (Soil Survey Staff 2014: p.28) is defined as a thermal condition in which a material (including soil material) remains below 0 C for 2 or more years in succession
             permafrost <- any(apply(soiltemp.yr.all$val[simTime$index.useyr, -1, drop = FALSE], 2, function(x) {
@@ -5441,7 +5442,7 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
                     "} and available are {",
                     paste(layers_depth, collapse = ", "), "}"))
 
-              swp_dy_nrsc <- get_SWPmatric_aggL(vwc_dy_nrsc,
+              swp_dy_nrsc <- get_SWPmatric_aggL(vwc_dy_nrsc, texture. = texture,
                 sand. = soildat[, "sand_frac"], clay. = soildat[, "clay_frac"])
             }
 

--- a/2_SWSF_p4of4_Code_v51.R
+++ b/2_SWSF_p4of4_Code_v51.R
@@ -5532,7 +5532,7 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
             
               #Days where moists in half of the Lanh soil depth (and not soil layers!)
               n_Lanh <- length(i_Lanh)
-              width_Lanh <- diff(soildat[, "depth_cm"])[i_Lanh]
+              width_Lanh <- diff(c(0, soildat[, "depth_cm"]))[i_Lanh] # stopifnot(sum(width_Lanh) == Lanh_depth[2] - Lanh_depth[1])
               temp <- swp_dy_nrsc[wdays_index, i_Lanh, drop = FALSE] > SWP_dry
               temp <- temp * matrix(width_Lanh, nrow = sum(wdays_index), ncol = length(i_Lanh), byrow = TRUE)
               Lanh_Dry_Half <- .rowSums(temp, m = sum(wdays_index), n = n_Lanh) <= sum(width_Lanh) / 2

--- a/2_SWSF_p4of4_Code_v51.R
+++ b/2_SWSF_p4of4_Code_v51.R
@@ -4258,12 +4258,12 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				}
 			}
 		}
-		get_SWPmatric_aggL <- function(vwcmatric){
-			val.top <- VWCtoSWP(vwcmatric$top, texture$sand.top, texture$clay.top)
-			val.bottom <- VWCtoSWP(vwcmatric$bottom, texture$sand.bottom, texture$clay.bottom)
+		get_SWPmatric_aggL <- function(vwcmatric, texture. = texture, sand. = sand, clay. = clay){
+			val.top <- VWCtoSWP(vwcmatric$top, texture.$sand.top, texture.$clay.top)
+			val.bottom <- VWCtoSWP(vwcmatric$bottom, texture.$sand.bottom, texture.$clay.bottom)
 			if(!is.null(vwcmatric$aggMean.top)){
-				aggMean.top <- VWCtoSWP(vwcmatric$aggMean.top, texture$sand.top, texture$clay.top)
-				aggMean.bottom <- VWCtoSWP(vwcmatric$aggMean.bottom, texture$sand.bottom, texture$clay.bottom)
+				aggMean.top <- VWCtoSWP(vwcmatric$aggMean.top, texture.$sand.top, texture.$clay.top)
+				aggMean.bottom <- VWCtoSWP(vwcmatric$aggMean.bottom, texture.$sand.bottom, texture.$clay.bottom)
 				return(list(top=val.top, bottom=val.bottom, aggMean.top=aggMean.top, aggMean.bottom=aggMean.bottom))
 			}
 			if(!is.null(vwcmatric$val)){
@@ -4272,7 +4272,7 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				} else {
 					index.header <- 1
 				}
-				val <- cbind(vwcmatric$val[, index.header], VWCtoSWP(vwcmatric$val[, -index.header], sand, clay))
+				val <- cbind(vwcmatric$val[, index.header], VWCtoSWP(vwcmatric$val[, -index.header], sand., clay.))
 				return(list(val=val, top=val.top, bottom=val.bottom))
 			} else {
 				return(list(top=val.top, bottom=val.bottom))

--- a/2_SWSF_p4of4_Code_v51.R
+++ b/2_SWSF_p4of4_Code_v51.R
@@ -5279,22 +5279,6 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				  #Soil Survey Staff. 2014. Keys to soil taxonomy, 12th ed., USDA Natural Resources Conservation Service, Washington, DC.
 				  #Soil Survey Staff. 2010. Keys to soil taxonomy, 11th ed., USDA Natural Resources Conservation Service, Washington, DC.
 				  
-				  #function for the calculation of consecutive days
-				  consec<-function(x){
-				    result<-rle(diff(x))
-				    result
-				    if(x[1]==TRUE){
-				      result2<-max(result$length[(seq(1,length(result$length),4))])
-				    }else{
-				      if(length(result$length)>2)
-				        result2<-max(result$length[seq(3,length(result$length),4)])+1
-				      if(length(result$length)==2)
-				        result2<-result$lengths[2]
-				      if(length(result$length)==1)  
-				        result2<-result$lengths[1]
-				    }
-				    return(result2)
-				  }
 				  #Result containers
 				  Tregime_names <- c("Hyperthermic", "Thermic", "Mesic", "Frigid", "Cryic", "Gelic")
 				  Tregime <- rep(0, times=length(Tregime_names))
@@ -5600,7 +5584,7 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				      ConditionalDF$COND1_1 <- ConditionalDF$AnyMoistDaysCumAbove5C > (.5 * ConditionalDF$SoilAbove5C)
 				      #Cond2 - Moist in SOME or all parts for less than 90 CONSECUTIVE days when the the soil temperature at a depth of 50cm is above 8C                                             
 				      ConditionalDF$COND2_Test <- ifelse(ConditionalDF$MCS_Dry_All == FALSE & ConditionalDF$T50_at8C == TRUE, TRUE,FALSE)#TRUE = where are both these conditions met
-				      MoistDaysConsecAbove8C <- with(ConditionalDF,tapply(COND2_Test,Years,function(x) max.duration(x)))				      #Consecutive days of Moist soil @ Conditions
+				      MoistDaysConsecAbove8C <- with(ConditionalDF,tapply(COND2_Test, Years, max.duration))				      #Consecutive days of Moist soil @ Conditions
 				      ConditionalDF<-merge(ConditionalDF, data.frame(Years = names(MoistDaysConsecAbove8C),MoistDaysConsecAbove8C=MoistDaysConsecAbove8C,row.names=NULL),by='Years')
 				      ConditionalDF$COND2 <- ConditionalDF$MoistDaysConsecAbove8C < 90 & ConditionalDF$MoistDaysConsecAbove8C > 0 # TRUE = moist less than 90 consecutive days , FALSE = moist more than 90 consecutive days
 				      
@@ -5616,7 +5600,7 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				      ConditionalDF$COND5 <-  abs(ConditionalDF$T50djf - ConditionalDF$T50jja) > 6 #TRUE - Greater than 6, FALSE - Less than 6
 				      
 				      #COND6 - Dry in ALL parts LESS than 45 CONSECUTIVE days in the 4 months following the summer solstice
-				      DryDaysConsecSummer <- with(ConditionalDF[ConditionalDF$DOY %in% c(172:293),], tapply(MCS_Dry_All,Years,function(x) max.duration(x)))#Consecutive days of dry soil after summer solsitice
+				      DryDaysConsecSummer <- with(ConditionalDF[ConditionalDF$DOY %in% c(172:293),], tapply(MCS_Dry_All, Years, max.duration))#Consecutive days of dry soil after summer solsitice
 				      ConditionalDF <- merge(ConditionalDF, data.frame(Years = names(DryDaysConsecSummer),DryDaysConsecSummer = DryDaysConsecSummer,row.names=NULL),by='Years')
 				      ConditionalDF$COND6 <- ConditionalDF$DryDaysConsecSummer < 45 # TRUE = dry less than 45 consecutive days 
 				      
@@ -5626,12 +5610,12 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				      ConditionalDF$COND7 <- ConditionalDF$MoistDaysCumAny > 180 #TRUE = Not Dry or Moist for as long 180 cumlative days
 				      
 				      #Cond8 - MCS is MOIST in SOME parts for more than 90 CONSECUTIVE days
-				      MoistDaysConsecAny <- with(ConditionalDF,tapply(MCS_Dry_All,Years,function(x) max.duration(!x))) #Consecutive days of Moist soil
+				      MoistDaysConsecAny <- with(ConditionalDF,tapply(MCS_Dry_All,Years, function(x) max.duration(!x))) #Consecutive days of Moist soil
 				      ConditionalDF<-merge(ConditionalDF, data.frame(Years = names(MoistDaysConsecAny),MoistDaysConsecAny=MoistDaysConsecAny,row.names=NULL),by='Years')
 				      ConditionalDF$COND8 <- ConditionalDF$MoistDaysConsecAny > 90 # TRUE = Moist more than 90 Consecutive Days 
 				      
 				      #COND9 - Moist in ALL parts MORE than 45 CONSECUTIVE days in the 4 months following the winter solstice
-				      MoistDaysConsecWinter <- with(ConditionalDF[ConditionalDF$DOY %in% c(355:365,1:111),], tapply(MCS_Moist_All,Years,function(x) max.duration(x)))#Consecutive days of moist soil after winter solsitice
+				      MoistDaysConsecWinter <- with(ConditionalDF[ConditionalDF$DOY %in% c(355:365,1:111),], tapply(MCS_Moist_All, Years, max.duration))#Consecutive days of moist soil after winter solsitice
 				      ConditionalDF <- merge(ConditionalDF, data.frame(Years = names(MoistDaysConsecWinter),MoistDaysConsecWinter = MoistDaysConsecWinter,row.names=NULL),by='Years')
 				      ConditionalDF$COND9<-ConditionalDF$MoistDaysConsecWinter > 45 # TRUE = moist more than 45 consecutive days 
 				     

--- a/2_SWSF_p4of4_Code_v51.R
+++ b/2_SWSF_p4of4_Code_v51.R
@@ -4519,7 +4519,7 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 					tempdat[,3] <- swProd_MonProd_tree(swRunScenariosData[[sc]])[,2]*swProd_MonProd_tree(swRunScenariosData[[sc]])[,3]
 					tempdat[,4] <- swProd_MonProd_forb(swRunScenariosData[[sc]])[,2]*swProd_MonProd_forb(swRunScenariosData[[sc]])[,3]
 
-					sumWeightedLiveBiomassByMonth <- apply(sweep(tempdat, MARGIN=2, fracs, FUN="*"), MARGIN=1, function(x) sum(x)) #sweep out fractionals, and sum over rows
+					sumWeightedLiveBiomassByMonth <- apply(sweep(tempdat, MARGIN=2, fracs, FUN="*"), MARGIN=1, sum) #sweep out fractionals, and sum over rows
 					maxMonth <- which(sumWeightedLiveBiomassByMonth==max(sumWeightedLiveBiomassByMonth)) #returns index, which is the month, of max bio
 					meanPeakMonth <- circ.mean(maxMonth, 12)
 					duration <- circ.range(maxMonth, 12)+1
@@ -5346,19 +5346,21 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				  #Permafrost (Soil Survey Staff 2014: p.28) is defined as a thermal condition in which a material (including soil material) remains below 0 C for 2 or more years in succession
 				  permafrost <- any(apply(soiltemp.yr.all$val[simTime$index.useyr, -1, drop=FALSE], 2, FUN=function(x) {
 				    temp <- rle(x < 0)
-				    res <- (any(temp$values) && any(temp$lengths[temp$values] >= 2))
+				    any(temp$values) && any(temp$lengths[temp$values] >= 2)
 				  }))
 				  
 				  ##Calculate soil temperature at necessary depths using a weighted mean
-				  if(calc50<-stemp[i_depth50, "depth_cm"] != Fifty_depth) {
-				  stemp<-stemp[c(1:i_depth50,NA,(i_depth50+1):dim(stemp)[1]),]
-				  weights50 <- c(abs(Fifty_depth-stemp[i_depth50+2,"depth_cm"]),abs(Fifty_depth-stemp[i_depth50,"depth_cm"]))
-				  stemp[(i_depth50+1),1]<-Fifty_depth
-				  i_depth50 <- findInterval(Fifty_depth, vec=stemp[, "depth_cm"])
+				  calc50 <- !(stemp[i_depth50, "depth_cm"] == Fifty_depth)
+				  if (calc50) {
+					stemp<-stemp[c(1:i_depth50,NA,(i_depth50+1):dim(stemp)[1]),]
+					weights50 <- c(abs(Fifty_depth-stemp[i_depth50+2,"depth_cm"]),abs(Fifty_depth-stemp[i_depth50,"depth_cm"]))
+					stemp[(i_depth50+1),1]<-Fifty_depth
+					i_depth50 <- findInterval(Fifty_depth, vec=stemp[, "depth_cm"])
 				  }
 				  
 				  i_MCS1 <- findInterval(MCS_depth[1], vec=stemp[, "depth_cm"])
-				  if(calcMCS1<-MCS_depth[1] %in% stemp[,"depth_cm"] == FALSE) {
+				  calcMCS1 <- !(MCS_depth[1] %in% stemp[,"depth_cm"])
+				  if (calcMCS1) {
 				    stemp<-stemp[c(1:i_MCS1,NA,(i_MCS1+1):dim(stemp)[1]),]
 				    weightsMCS1 <- c(abs(MCS_depth[1]-stemp[i_MCS1+2,"depth_cm"]),abs(MCS_depth[1]-stemp[i_MCS1,"depth_cm"]))
 				    stemp[(i_MCS1+1),1]<-MCS_depth[1]
@@ -5366,7 +5368,8 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				  }
 				  
 				  i_MCS2 <- findInterval(MCS_depth[2], vec=stemp[, "depth_cm"])
-				  if(calcMCS2<-MCS_depth[2] %in% stemp[,"depth_cm"] == FALSE) {
+				  calcMCS2 <- !(MCS_depth[2] %in% stemp[,"depth_cm"])
+				  if (calcMCS2) {
 				    stemp<-stemp[c(1:i_MCS2,NA,(i_MCS2+1):dim(stemp)[1]),]
 				    weightsMCS2 <- c(abs(MCS_depth[2]-stemp[i_MCS2+2,"depth_cm"]),abs(MCS_depth[2]-stemp[i_MCS2,"depth_cm"]))
 				    stemp[(i_MCS2+1),1]<-MCS_depth[2]
@@ -5511,10 +5514,10 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				      #days where T @ 50 is > 0c
 				      T50_at0C <-lapply(wyears_normal, FUN=function(yr) T50[wateryears == yr] > 0)
 				      #Days where moists in half of the Lanh soil depth
-				      Lanh_Moist <- lapply(wyears_normal, FUN=function(Year) Days_str[wateryears == Year,(2+i_Lanh_depth)] > SWP_dry)
-				      if(iL == 1){Lanh_Dry_Half<-lapply(Lanh_Moist,function(x) y<-ifelse(x == TRUE, FALSE, TRUE))#IF moist in one layer, moist in greater than half
+				      Lanh_Moist <- lapply(wyears_normal, FUN=function(Year) Days_str[wateryears == Year,2+i_Lanh_depth] > SWP_dry)
+				      if(iL == 1){Lanh_Dry_Half<-lapply(Lanh_Moist,function(x) !x)#IF moist in one layer, moist in greater than half
 				      }else{
-				        Lanh_Dry_Half<-lapply(Lanh_Moist,function(x) y<-ifelse((rowSums(x) <= (.5 * dim(x)[2])) == TRUE, TRUE, FALSE))#True - dry in greater than half of layers
+				        Lanh_Dry_Half<-lapply(Lanh_Moist,function(x) rowSums(x) <= .5 * dim(x)[2])#True - dry in greater than half of layers
 				      }
 				      #Conditions for Anhydrous soil delineation
 				      LanhConditionalDF<-data.frame(Years = rep(wyears_normal,lapply(T50_at0C,length)),
@@ -5530,14 +5533,14 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				      LanhConditionalDF$COND2<-LanhConditionalDF$MATLanh <= 5
 				      #In the Lahn Depth, 1/2 of soil dry > 1/2 CUMULATIVE days when Mean Annual ST > 0C
 				      LanhConditionalDF$COND3_Test <- (LanhConditionalDF$Lanh_Dry_Half == LanhConditionalDF$T50_at0C)#TRUE = where are both these conditions met
-				      HalfDryDaysCumAbove0C <- with(LanhConditionalDF, tapply(COND3_Test,Years,function(x) sum(x == TRUE)))
+				      HalfDryDaysCumAbove0C <- with(LanhConditionalDF, tapply(COND3_Test,Years, sum))
 				      LanhConditionalDF <- merge(LanhConditionalDF, data.frame(Years=names(HalfDryDaysCumAbove0C),HalfDryDaysCumAbove0C=HalfDryDaysCumAbove0C,row.names=NULL),by='Years')
-				      SoilAbove0C <- with(LanhConditionalDF, tapply(T50_at0C,Years,function(x) sum(x == TRUE)))
+				      SoilAbove0C <- with(LanhConditionalDF, tapply(T50_at0C,Years, sum))
 				      LanhConditionalDF <- merge(LanhConditionalDF, data.frame(Years=names(SoilAbove0C),SoilAbove0C=SoilAbove0C,row.names=NULL),by='Years')
 				      LanhConditionalDF$COND3 <- LanhConditionalDF$HalfDryDaysCumAbove0C > (.5 * LanhConditionalDF$SoilAbove0C)#TRUE = Half of soil layers are dry greater than half the days where MAST >0c
 				      
 				      LanhConditionalDF2<-unique(LanhConditionalDF[,c('Years','COND1','COND2','COND3')])
-				      LanhConditionalDF3<-apply(LanhConditionalDF2[,2:length(LanhConditionalDF2)],2,function(x) length(which(x==TRUE)) >= length(which(x==FALSE)))
+				      LanhConditionalDF3<-apply(LanhConditionalDF2[,2:length(LanhConditionalDF2)],2, function(x) sum(x) >= sum(!x))
 				      #Structures used for MCS delineation
 				      #days where T @ 50cm exceeds 5C and 8C
 				      T50_at5C <-lapply(wyears_normal, FUN=function(yr) T50[wateryears == yr] > 5)
@@ -5550,8 +5553,8 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				        MCS_Moist_All<-MCS_Moist
 				        MCS_Dry_All<-MCS_Dry
 				      }else{
-				        MCS_Moist_All<-lapply(MCS_Moist,function(x) y<-ifelse(eval(parse(text=paste0("x[,",1:iM,"]",c(rep("&",iM-1),"")))) == TRUE,TRUE,FALSE))
-				        MCS_Dry_All<-lapply(MCS_Dry,function(x) y<-ifelse(eval(parse(text=paste0("x[,",1:iM,"]",c(rep("&",iM-1),"")))) == TRUE,TRUE,FALSE))
+				        MCS_Moist_All<-lapply(MCS_Moist,function(x) eval(parse(text=paste0("x[,",1:iM,"]",c(rep("&",iM-1),"")))))
+				        MCS_Dry_All<-lapply(MCS_Dry,function(x) eval(parse(text=paste0("x[,",1:iM,"]",c(rep("&",iM-1),"")))))
 				      }
 				      #Build Conditional Data.frame
 				      ConditionalDF<-data.frame(Years = rep(wyears_normal,lapply(T50_at5C,length)),
@@ -5566,28 +5569,28 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				                                )
 				      
 				       #COND1 - Dry in ALL parts for more than half of the CUMLATIVE days per year when the soil temperature at a depth of 50cm is above 5C  
-				      ConditionalDF$COND1_Test <- ifelse(ConditionalDF$MCS_Dry_All == TRUE & ConditionalDF$T50_at5C ==TRUE,TRUE,FALSE)#TRUE = where are both these conditions met
-				      DryDaysCumAbove5C <- with(ConditionalDF, tapply(COND1_Test,Years,function(x) sum(x == TRUE)))
+				      ConditionalDF$COND1_Test <- ConditionalDF$MCS_Dry_All & ConditionalDF$T50_at5C	#TRUE = where are both these conditions met
+				      DryDaysCumAbove5C <- with(ConditionalDF, tapply(COND1_Test,Years, sum))
 				      ConditionalDF <- merge(ConditionalDF,data.frame(Years = names(DryDaysCumAbove5C), DryDaysCumAbove5C = DryDaysCumAbove5C, row.names=NULL), by = 'Years')
-				      SoilAbove5C <- with(ConditionalDF, tapply(T50_at5C,Years,function(x) sum(x == TRUE)))
+				      SoilAbove5C <- with(ConditionalDF, tapply(T50_at5C,Years, sum))
 				      ConditionalDF <- merge(ConditionalDF,data.frame(Years = names(SoilAbove5C), SoilAbove5C = SoilAbove5C, row.names=NULL), by = 'Years')
 				      ConditionalDF$COND1 <- ConditionalDF$DryDaysCumAbove5C > (.5 * ConditionalDF$SoilAbove5C)#TRUE =Soils are dry greater than 1/2 cumulative days/year
 				      
 				      #COND1.1 - Moist in SOME or ALL parts for more than half of the CUMLATIVE days per year when the soil temperature at a depth of 50cm is above 5
 				      #!MCs_Dry_All = MCS_ Moist Any
-				      #This Test is kind of redundant basically if COND1 is TRUE than COND1.1 is FALSE
-				      ConditionalDF$COND1_1_Test <- ifelse(ConditionalDF$MCS_Dry_All == FALSE & ConditionalDF$T50_at5C ==TRUE,TRUE,FALSE)#TRUE = where are both these conditions met
-				      AnyMoistDaysCumAbove5C <-  with(ConditionalDF, tapply(COND1_1_Test,Years,function(x) sum(x == TRUE)))
+				      #This Test is kind of redundant basically if COND1 is TRUE than 
+				      ConditionalDF$COND1_1_Test <- !ConditionalDF$MCS_Dry_All & ConditionalDF$T50_at5C	#TRUE = where are both these conditions met
+				      AnyMoistDaysCumAbove5C <-  with(ConditionalDF, tapply(COND1_1_Test,Years, sum))
 				      ConditionalDF <- merge(ConditionalDF,data.frame(Years = names(AnyMoistDaysCumAbove5C), AnyMoistDaysCumAbove5C = AnyMoistDaysCumAbove5C, row.names=NULL), by = 'Years')
 				      ConditionalDF$COND1_1 <- ConditionalDF$AnyMoistDaysCumAbove5C > (.5 * ConditionalDF$SoilAbove5C)
 				      #Cond2 - Moist in SOME or all parts for less than 90 CONSECUTIVE days when the the soil temperature at a depth of 50cm is above 8C                                             
-				      ConditionalDF$COND2_Test <- ifelse(ConditionalDF$MCS_Dry_All == FALSE & ConditionalDF$T50_at8C == TRUE, TRUE,FALSE)#TRUE = where are both these conditions met
+				      ConditionalDF$COND2_Test <- !ConditionalDF$MCS_Dry_All & ConditionalDF$T50_at8C	#TRUE = where are both these conditions met
 				      MoistDaysConsecAbove8C <- with(ConditionalDF,tapply(COND2_Test, Years, max.duration))				      #Consecutive days of Moist soil @ Conditions
 				      ConditionalDF<-merge(ConditionalDF, data.frame(Years = names(MoistDaysConsecAbove8C),MoistDaysConsecAbove8C=MoistDaysConsecAbove8C,row.names=NULL),by='Years')
 				      ConditionalDF$COND2 <- ConditionalDF$MoistDaysConsecAbove8C < 90 & ConditionalDF$MoistDaysConsecAbove8C > 0 # TRUE = moist less than 90 consecutive days , FALSE = moist more than 90 consecutive days
 				      
 				      #COND3 - MCS is Not dry in ANY part as long as 90 CUMLATIVE days - Can't be dry longer than 90 cum days
-				      DryDaysCumAny <- with(ConditionalDF, tapply(MCS_Moist_All,Years,function(x) sum(x == FALSE)))#Number of days where any soils are dry
+				      DryDaysCumAny <- with(ConditionalDF, tapply(MCS_Moist_All,Years,function(x) sum(!x)))#Number of days where any soils are dry
 				      ConditionalDF <- merge(ConditionalDF,data.frame(Years = names(DryDaysCumAny), DryDaysCumAny = DryDaysCumAny, row.names=NULL), by = 'Years')
 				      ConditionalDF$COND3 <- ConditionalDF$DryDaysCumAny < 90 #TRUE = Not Dry for as long 90 cumlative days,FALSE = Dry as long as as 90 Cumlative days
 				      
@@ -5603,7 +5606,7 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				      ConditionalDF$COND6 <- ConditionalDF$DryDaysConsecSummer < 45 # TRUE = dry less than 45 consecutive days 
 				      
 				      #COND7 - MCS is MOIST in SOME parts for more than 180 CUMLATIVE days
-				      MoistDaysCumAny <- with(ConditionalDF, tapply(MCS_Dry_All,Years,function(x) sum(x == FALSE)))#Number of days where any soils are moist
+				      MoistDaysCumAny <- with(ConditionalDF, tapply(MCS_Dry_All,Years,function(x) sum(!x)))#Number of days where any soils are moist
 				      ConditionalDF <- merge(ConditionalDF,data.frame(Years = names(MoistDaysCumAny), MoistDaysCumAny = MoistDaysCumAny, row.names=NULL), by = 'Years')
 				      ConditionalDF$COND7 <- ConditionalDF$MoistDaysCumAny > 180 #TRUE = Not Dry or Moist for as long 180 cumlative days
 				      
@@ -5618,56 +5621,59 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				      ConditionalDF$COND9<-ConditionalDF$MoistDaysConsecWinter > 45 # TRUE = moist more than 45 consecutive days 
 				     
 				      ConditionalDF2<-unique(ConditionalDF[,c('Years','COND1','COND1_1','COND2','COND3','COND4','COND5','COND6','COND7','COND8','COND9')])
-				      ConditionalDF3<-apply(ConditionalDF2[,2:length(ConditionalDF2)],2,function(x) length(which(x==TRUE)) >= length(which(x==FALSE)))
+				      ConditionalDF3<-apply(ConditionalDF2[,2:length(ConditionalDF2)],2,function(x) sum(x) >= sum(!x))
 				      
 				      #---Soil moisture regime: based on Chambers et al. 2014: Appendix 3 and on Soil Survey Staff 2010: p.26-28/Soil Survey Staff 2014: p.28-31
 				      #we ignore 'Aquic'
 				      
 				      #Anhydrous condition: Soil Survey Staff 2010: p.16/Soil Survey Staff 2014: p.18
 				      #we ignore test for 'ice-cemented permafrost' and 'rupture-resistance class'
-				      if(LanhConditionalDF3['COND1'] ==TRUE && LanhConditionalDF3['COND2'] == TRUE && LanhConditionalDF3['COND3'] == TRUE) Sregime["Anhydrous"] <- 1
+				      if(LanhConditionalDF3['COND1'] && LanhConditionalDF3['COND2'] && LanhConditionalDF3['COND3'])
+				      	Sregime["Anhydrous"] <- 1
 				      
 				      #Aridic soil moisture regime; The limits set for soil temperature exclude from these soil moisture regimes soils in the very cold and dry polar regions and in areas at high elevations. Such soils are considered to have anhydrous condition
-				      if(ConditionalDF3['COND1'] == TRUE && ConditionalDF3['COND2'] == TRUE && ConditionalDF3['COND3'] == FALSE) Sregime["Aridic"] <- 1
+				      if(ConditionalDF3['COND1'] && ConditionalDF3['COND2'] && !ConditionalDF3['COND3'])
+				      	Sregime["Aridic"] <- 1
 				      
 				      #Udic soil moisture regime - #we ignore test for 'three- phase system' during T50 > 5
-				      if(ConditionalDF3['COND3'] == TRUE) 
-				          if(ConditionalDF3['COND4'] == FALSE && ConditionalDF3['COND5'] == TRUE){
-				            if(ConditionalDF3['COND6'] == TRUE) Sregime["Udic"] <- 1
-				          }else{
-				          Sregime["Udic"] <- 1
-				        }
+						if (ConditionalDF3['COND3']) 
+							if (!ConditionalDF3['COND4'] && ConditionalDF3['COND5']) {
+								if (ConditionalDF3['COND6'])
+									Sregime["Udic"] <- 1
+								} else {
+									Sregime["Udic"] <- 1
+							}
 				      
 				      #Ustic soil moisture regime
-				        if(!permafrost)
-				          if(ConditionalDF3['COND4'] == TRUE || ConditionalDF3['COND5'] == FALSE)
-				            if(ConditionalDF3['COND3'] == FALSE && (ConditionalDF3['COND7'] == TRUE || ConditionalDF3['COND8'] == TRUE)) Sregime["Ustic"] <- 1
-				        if(!permafrost)
-				            if(ConditionalDF3['COND4'] == FALSE && ConditionalDF3['COND5'] == TRUE)
-				              if(ConditionalDF3['COND3']==FALSE && ConditionalDF3['COND1'] == FALSE)
-				                if(ConditionalDF3['COND9']==TRUE){
-				                  if(ConditionalDF3['COND6']==TRUE) Sregime["Ustic"] <- 1
-				                } else {
-				                  Sregime["Ustic"]<-1
-				                }
+						if (!permafrost && ConditionalDF3['COND4'] || !ConditionalDF3['COND5'])
+							if (!ConditionalDF3['COND3'] && (ConditionalDF3['COND7'] || ConditionalDF3['COND8']))
+								Sregime["Ustic"] <- 1
+							if (!ConditionalDF3['COND4'] && ConditionalDF3['COND5'] &&
+								!ConditionalDF3['COND3'] && !ConditionalDF3['COND1'])
+								if (ConditionalDF3['COND9']) {
+									if (ConditionalDF3['COND6'])
+										Sregime["Ustic"] <- 1
+									} else {
+										Sregime["Ustic"]<-1
+								}
 
 				     #Xeric soil moisture regime
-				       if(ConditionalDF3['COND6'] == FALSE && ConditionalDF3['COND9'] == TRUE &&
-				          ConditionalDF3['COND4'] ==  FALSE  && ConditionalDF3['COND5'] ==TRUE &&
-				          (ConditionalDF3['COND1_1'] == TRUE || ConditionalDF3['COND2'] == FALSE)){
-				         Sregime["Xeric"] <- 1
-				       }
+						if (!ConditionalDF3['COND6'] && ConditionalDF3['COND9'] &&
+							!ConditionalDF3['COND4'] && ConditionalDF3['COND5'] &&
+							(ConditionalDF3['COND1_1'] || !ConditionalDF3['COND2'])){
+							Sregime["Xeric"] <- 1
+						}
 				      regimes_done <- TRUE
 				      
-				      SoilAbove0C<-round(mean(LanhConditionalDF$SoilAbove0C),0)
-				      SoilAbove5C<-round(mean(ConditionalDF$SoilAbove5C),0)
-				      DryDaysCumAbove5C<-round(mean(ConditionalDF$DryDaysCumAbove5C),0)
-				      MoistDaysConsecAbove8C<-round(mean(ConditionalDF$MoistDaysConsecAbove8C),0)
-				      DryDaysConsecSummer<-round(mean(ConditionalDF$DryDaysConsecSummer),0)
-				      MoistDaysConsecAny<-round(mean(ConditionalDF$MoistDaysConsecAny),0)
-				      MoistDaysCumAny<-round(mean(ConditionalDF$MoistDaysCumAny),0)
-				      DryDaysCumAny<-round(mean(ConditionalDF$DryDaysCumAny),0)
-				      MoistDaysConsecWinter<-round(mean(ConditionalDF$MoistDaysConsecWinter),0)
+				      SoilAbove0C<-round(mean(LanhConditionalDF$SoilAbove0C))
+				      SoilAbove5C<-round(mean(ConditionalDF$SoilAbove5C))
+				      DryDaysCumAbove5C<-round(mean(ConditionalDF$DryDaysCumAbove5C))
+				      MoistDaysConsecAbove8C<-round(mean(ConditionalDF$MoistDaysConsecAbove8C))
+				      DryDaysConsecSummer<-round(mean(ConditionalDF$DryDaysConsecSummer))
+				      MoistDaysConsecAny<-round(mean(ConditionalDF$MoistDaysConsecAny))
+				      MoistDaysCumAny<-round(mean(ConditionalDF$MoistDaysCumAny))
+				      DryDaysCumAny<-round(mean(ConditionalDF$DryDaysCumAny))
+				      MoistDaysConsecWinter<-round(mean(ConditionalDF$MoistDaysConsecWinter))
 				      
 				      rm(i_MCS, MCS, i_Lanh_depth, iL)
 				  
@@ -5692,12 +5698,13 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				  }
 				  }  
 				  
-				  resMeans[nv:(nv+4+15+length(Tregime_names)+length(Sregime_names))] <- c(Fifty_depth, MCS_depth[1:2], Lanh_depth[1:2], as.integer(permafrost),
-				                                                                           mean(MATLanh),mean(MAT50), mean(T50jja), mean(T50djf),CSPartSummer, 
-  				                                                                          SoilAbove0C,SoilAbove5C,DryDaysCumAbove5C,MoistDaysConsecAbove8C,
-  				                                                                          DryDaysConsecSummer,MoistDaysConsecAny,MoistDaysCumAny,DryDaysCumAny,MoistDaysConsecWinter,
-				                                                                            Tregime, Sregime)
-				  nv <- nv+4+15+length(Tregime_names)+length(Sregime_names)+1
+				  nv_new <- nv+4+15+length(Tregime_names)+length(Sregime_names)+1
+				  resMeans[nv:(nv_new - 1)] <- c(Fifty_depth, MCS_depth[1:2], Lanh_depth[1:2], as.integer(permafrost),
+					mean(MATLanh),mean(MAT50), mean(T50jja), mean(T50djf),CSPartSummer, 
+					SoilAbove0C,SoilAbove5C,DryDaysCumAbove5C,MoistDaysConsecAbove8C,
+					DryDaysConsecSummer,MoistDaysConsecAny,MoistDaysCumAny,DryDaysCumAny,MoistDaysConsecWinter,
+					Tregime, Sregime)
+				  nv <- nv_new
 				  
 				  to_del <- c("SWP_dry", "SWP_sat", "impermeability", "Tregime_names", "Sregime_names", "stemp", "sand_temp", "clay_temp", "imp_depth", 
 				              "MCS_depth", "Fifty_depth", "Lanh_depth", "permafrost", "MAT50","MATLanh","T50jja", "T50djf", "CSPartSummer", "T50_at5C", "T50_at8C","T50_at0C",

--- a/2_SWSF_p4of4_Code_v51.R
+++ b/2_SWSF_p4of4_Code_v51.R
@@ -5506,8 +5506,6 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				    wyears_normal <- (simstartyr+1):endyr
 				    wyears_index <- findInterval(wyears_normal,wyears)
 
-				    
-				    if(!be.quiet) if(length(wyears_normal) <= 2) {print("Number of normal years not long enough to calculated NRCS Soil Moisture Regimes. Try increasing length of simulation")}
 				    if(length(wyears_normal) > 2){
 				      #Structures used Lanh delinieation
 				      #days where T @ 50 is > 0c
@@ -5674,6 +5672,8 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				      rm(i_MCS, MCS, i_Lanh_depth, iL)
 				  
 				    } else {
+				    	if(!be.quiet)
+				    		print(paste0(i_labels, "Number of normal years not long enough to calculated NRCS Soil Moisture Regimes. Try increasing length of simulation"))
 				      Sregime[] <- NA
 				      Tregime[] <- NA
 				    }
@@ -5681,13 +5681,16 @@ do_OneSite <- function(i_sim, i_labels, i_SWRunInformation, i_sw_input_soillayer
 				    rm(wateryears, wyears, i_depth50, T50, MAP, normal1, normal2, wyears_normal,wyears_index)
 				    
 				  } else {
-				    Tregime[] <- NA
+					print(paste0(i_labels, " failed aggregating for NRCS soil regimes",
+						" because of insufficient soil layers: required would be {",
+							paste(sort(unique(c(Fifty_depth, MCS_depth))), collapse = ", "), "} and available are {",
+							paste(stemp[, "depth_cm"], collapse = ", "), "}",
+						" or because of invariant/turned-off soil temperature: sd(Tsoil) is ",
+							signif(sd(soiltemp.yr.all$val[, -1]), 3), "C"))
+					Tregime[] <- NA
 				    Sregime[] <- NA
 				  }
 				  }  
-				  print(i_labels)
-				  print(Sregime)
-				  print(Tregime)
 				  
 				  resMeans[nv:(nv+4+15+length(Tregime_names)+length(Sregime_names))] <- c(Fifty_depth, MCS_depth[1:2], Lanh_depth[1:2], as.integer(permafrost),
 				                                                                           mean(MATLanh),mean(MAT50), mean(T50jja), mean(T50djf),CSPartSummer, 

--- a/tests/Test_projects/Test4_AllOverallAggregations/2_SWSF_p1of4_Settings_v51.R
+++ b/tests/Test_projects/Test4_AllOverallAggregations/2_SWSF_p1of4_Settings_v51.R
@@ -352,8 +352,8 @@ output_aggregates <- c(
 						"dailySWPextremes", 1,
 						"dailyRechargeExtremes", 1,
 					#---Aggregation: Ecological dryness
-						"dailyNRCS_SoilMoistureTemperatureRegimes", 0, #Requires at least soil layers at 10, 20, 30, 50, 60, 90 cm
-						"dailyNRCS_Chambers2014_ResilienceResistance", 0, #Requires "dailyNRCS_SoilMoistureTemperatureRegimes"
+						"dailyNRCS_SoilMoistureTemperatureRegimes", 1, #Requires at least soil layers at 10, 20, 30, 50, 60, 90 cm
+						"dailyNRCS_Chambers2014_ResilienceResistance", 1, #Requires "dailyNRCS_SoilMoistureTemperatureRegimes"
 						"dailyWetDegreeDays", 1,
 						"dailyThermalDrynessStartEnd", 1,
 						"dailyThermalSWPConditionCount", 1,


### PR DESCRIPTION
 Fixes to NRCS_SoilMoistureTemperatureRegimes
- Function consec() which calculated duration of consecutive days
incorrectly under certain conditions, replaced with max.duration()
[closes #11]
- Old code created additional soil layers by linear interpolation of
output variables such as soiltemp.yr.all and swp.dy.all if required
soil layers were not available, but did not delete these afterwards.
Downstream code was therefore using incorrect values/dimensions. —> New
code copies output variables (‘soiltemp_nrsc’, ‘vwc_dy_nrsc’, and
‘swp_dy_nrsc’) before adding soil layers to the copies.
- Soil layers were not added if missing for ‘anhydrous layer
definition’. This is now done.
- Old code determined indices for depth50, MCS1, and MCS2 sequentially
while updating the soil layer structure in each step and only
afterwards interpolating values for the new layers. There were two
problems: (1) i_depth50 was incorrect if MCS1 required adding a layer
more shallow than depth50; (2) two soil layers could have been added
directly adjacent - with no data to interpolate. —> New code determines
additional soil layers and calculates values immediately.
- Old code calculated SWP for new soil layers as the arithmetic mean
(weighted by the soil layer thickness). This is incorrect because the
soil water potential is not on a linear scale. —> New code calculates
VWC and then, after all interpolations are completed, converts to SWP
with the (updated) soil texture.
- Soil moisture regimes are based on ‘normal’ weather years. The
conditions were correctly calculated but then overwritten and all years
were used. —> New code uses the ‘normal’ weather years and not all
years.
- Old code calculated variables such as days with temperature above
some threshold for each year only to combine all the years into one
vector. —> new code doesn’t loop over years if not necessary.
- Old code was incorrectly introducing NAs when calculating DOYs —> new
code uses ‘simTime2$doy_ForEachUsedDay_NSadj’
- Old code switched between “NSadj” and not adjusted for
northern/southern hemisphere —> new code consistently uses “NSadj”
values