### PR TITLE
dbWork Invariant to includeYN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rSWSF
 Title: SOILWAT Simulation Framework
-Version: 1.11.0
-Date: 2016-12-13
+Version: 1.11.0-dbWork_invariant_to_includeYN
+Date: 2017-01-20
 Authors@R: c(person("Daniel", "Schlaepfer", email = "daniel.schlaepfer@unibas.ch", role = c("aut", "cre")),
       person("Caitlin", "Andrews", role = "ctb"),
       person("Ryan", "Murphy", role = "ctb"))

--- a/R/2_SWSF_p5of5_Functions_v51.R
+++ b/R/2_SWSF_p5of5_Functions_v51.R
@@ -172,81 +172,45 @@ isLeapYear <- compiler::cmpfun(function(y) {
   y %% 4 == 0 & (y %% 100 != 0 | y %% 400 == 0)
 })
 
-#' Iterator functions
-#'
-#' @param isim An integer value. A value of \code{runIDs_todo} as subset of \code{runIDs_total}, i.e., a consecutive index across loops 1+2b
-#' @param sc An integer value. The iterator position along \code{scenario_No}.
-#' @param scN An integer value. The number of (climate) scenarios used in the project, i.e., \eqn{scN == scenario_No}.
-#' @param runN An integer value. The number of runs/sites set up in the master input file, i.e., \eqn{runN == runsN_master}.
-#' @param runIDs An integer vector. The identification IDs of rows in the master file that are included, i.e., \eqn{runIDs == runIDs_sites}.
-#'
-#' @section NOTE:
-#'  Do not change the iterators without adjusting the design of the output databases!
-#'
-#' @section Simulation runs:
-#'  * Simulations are run over three nested loops
-#'    - loop1 (1...expN) nested in loop2b (1...runsN_sites) nested in loop3 (1...scenario_No)
-#'        - Note: loop3 (along scenarios) occurs within the function 'do_OneSite'
-#'        - Note: loop2b is a subset of loop2a (1...runsN_master)
-#'    - column 'include_YN' reduces 'site_id' to 'runIDs_sites'
-#'    - 'site_id' and 'P_id' are invariant to 'include_YN'
-#'
-#'  * Master input file: column 'include_YN' selects rows which are included in the simulation
-#'    - Note: rows of the master input file correspond to rows of the treatment input file
-#'    - column 'site_id' == consecutive identification numbers of all rows in the master file; this is treated as a unique (and stable) identifier of a site
-#'    - runsN_master == number of rows in the master file
-#'    - runsN_sites == number of rows in the master file that are included (runsN_sites <= max(site_id))
-#'    - runIDs_sites == identification of rows in the master file that are included
-#'
-#'  * Experimental input file: each row defines a condition which is applied to every runIDs_sites
-#'    - expN == number of experimental treatments
-#'
-#'  * The function 'do_OneSite' will be called n-times with n = runsN_total
-#'    - runsN_total == (number of included sites) x (number of experimental treatments)
-#'    - runIDs_total == consecutive identification numbers along runsN_total
-#'    - runIDs_done == values of runIDs_total that have already been processed by 'do_OneSite'
-#'    - runIDs_todo == values of runIDs_total that await simulation by 'do_OneSite'
-#'    - runsN_todo == number of runIDs_total that await simulation by 'do_OneSite'
-#'
-#'  * The function 'do_OneSite' could be called n-times with n = runsN_incl if all 'include_YN' were on
-#'    - runsN_incl == (number of sites) x (number of experimental treatments)
-#'
-#'  * The variable 'climate.conditions' defines climate conditions that are applied to each 'runIDs_total'
-#'    - scenario_No == number of climate conditions
-#'
-#'  * A grand total of n = runsN_Pid SoilWat runs could be carried out (n == number of rows in the output database)
-#'    - runsN_Pid == max(P_id) == runsN_incl x scenario_No
-#'    - P_id == a consecutive identification number for each possible SoilWat simulation; used as the ID for the output database
-#'
-#' @aliases it_exp it_site it_Pid
-#' @name iterators
-NULL
-#' @rdname iterators
-#' @return An integer value of the iterator position in loop 1 based on the position across loops 1+2b
-it_exp <- compiler::cmpfun(function(isim, runN) (isim - 1L) %/% runN + 1L)
-#' @rdname iterators
-#' @return An integer value of the iterator position across 'runIDs_sites', i.e., the position in loop 2 based on position across loops 1+2b
-it_site <- compiler::cmpfun(function(isim, runN, runIDs) runIDs[(isim - 1L) %% runN + 1L])
-#' @rdname iterators
-#' @return An integer value of the iterator position across all loops 1+2a+3, dependent on \code{include_YN}.
-it_Pid_old <- compiler::cmpfun(function(isim, sc, scN) (isim - 1L) * scN + sc)
-#' @rdname iterators
-#' @return An integer value of the iterator position across all loops 1+2a+3, invariant
-#'  to \code{include_YN}. A consecutive identification number for each possible SoilWat
-#'  simulation--used as the ID for the output database.
-it_Pid <- compiler::cmpfun(function(isim, sc, scN, runN, runIDs) {
-  ((it_exp(isim, runN) - 1L) * runN + it_site(isim, runN, runIDs) - 1L) * scN + sc
-})
 
+#' Test whether input represents a natural number
+#' @param x An integer, numeric, or complex vector, matrix, or array.
+#' @return A logical value.
+is.natural <- function(x) {
+  typeof(x) %in% c("integer", "double", "complex") &&
+  !is.null(x) && length(x) > 0 && !is.na(x) &&
+  isTRUE(all.equal(x, round(x))) && x > 0
+}
 
-## Tests
-#include_YN <- c(0, 0, 1, 0, 0, 1, 1, 0)
-#include_YN <- rep(1, 8)
-#t(sapply(runIDs_todo, function(isim) c(isim, it_site(isim, 8), it_exp(isim, 8), it_Pid(isim, 1, 3, 8), it_Pid_old(isim, 1))))
-#t(sapply(runIDs_total, function(isim) c(isim, it_site(isim, 8), it_exp(isim, 8), it_Pid(isim, 1, 3, 8), it_Pid_old(isim, 1))))
+#' The intersection on any number of vectors
+#'
+#' @param ... Any number of vectors or a list of vectors.
+#' @return A vector of the same mode as inputs.
+#' @seealso \code{\link{intersect}}
+intersect2 <- function(...) {
+  x <- list(...)
+  n <- length(x)
 
+  if (is.list(x[[1]]) && n == 1) {
+    x <- x[[1]]
+    n <- length(x)
+  }
 
+  res <- NULL
+  if (n > 1) {
+    if (all(lengths(x)) > 0) {
+      res <- x[[1]]
+      for (k in 2:n) {
+        res <- intersect(res, x[[k]])
+      }
+    }
 
+  } else {
+    res <- x[[1]]
+  }
+
+  res
+}
 
 #' @examples
 #'  month1 <- function() as.POSIXlt(seq(from = ISOdate(1980, 1, 1, tz = "UTC"),

--- a/R/SWSF_Indices.R
+++ b/R/SWSF_Indices.R
@@ -1,0 +1,109 @@
+#' Index functions
+#'
+#' @param isim An integer value. A value of \code{runIDs_todo} as subset of \code{runIDs_total}, i.e., a consecutive index across loops 1+2b
+#' @param sc An integer value. The index along \code{scenario_No}.
+#' @param scN An integer value. The number of (climate) scenarios used in the project, i.e., \eqn{scN == scenario_No}.
+#' @param runN An integer value. The number of runs/sites set up in the master input file, i.e., \eqn{runN == runsN_master}.
+#' @param runIDs An integer vector. The identification IDs of rows in the master file that are included, i.e., \eqn{runIDs == runIDs_sites}.
+#'
+#' @section NOTE:
+#'  Do not change the indices without adjusting the design of the output databases!
+#'
+#' @section Simulation runs:
+#'  * Simulations are run over three nested loops
+#'    - loop1 (1...expN) nested in loop2b (1...runsN_sites) nested in loop3 (1...scenario_No)
+#'        - Note: loop3 (along scenarios) occurs within the function 'do_OneSite'
+#'        - Note: loop2b is a subset of loop2a (1...runsN_master)
+#'    - column 'include_YN' reduces 'site_id' to 'runIDs_sites'
+#'    - 'site_id' and 'P_id' are invariant to 'include_YN'
+#'
+#'  * Master input file: column 'include_YN' selects rows which are included in the simulation
+#'    - Note: rows of the master input file correspond to rows of the treatment input file
+#'    - column 'site_id' == consecutive identification numbers of all rows in the master file; this is treated as a unique (and stable) identifier of a site
+#'    - runsN_master == number of rows in the master file
+#'    - runsN_sites == number of rows in the master file that are included (runsN_sites <= max(site_id))
+#'    - runIDs_sites == identification of rows in the master file that are included
+#'
+#'  * Experimental input file: each row defines a condition which is applied to every runIDs_sites
+#'    - expN == number of experimental treatments
+#'
+#'  * The function 'do_OneSite' will be called n-times with n = runsN_call
+#'    - runsN_job == (number of included sites) x (number of experimental treatments)
+#'    - runIDs_job == consecutive identification numbers along runsN_job
+#'    - runsN_total == (number of sites) x (number of experimental treatments)
+#'    - runIDs_total == consecutive identification numbers along runsN_total
+#'    - runIDs_done == values of runIDs_total that have already been processed by 'do_OneSite'
+#'    - runIDs_todo == values of runIDs_total that await simulation by 'do_OneSite'
+#'    - runsN_todo == number of runIDs_total that await simulation by 'do_OneSite'
+#'
+#'  * The function 'do_OneSite' could be called n-times with n = runsN_incl if all 'include_YN' were on
+#'    - runsN_incl == runsN_total
+#'
+#'  * The variable 'climate.conditions' defines climate conditions that are applied to each 'runIDs_total'
+#'    - scenario_No == number of climate conditions
+#'
+#'  * A grand total of n = runsN_Pid SoilWat runs could be carried out (n == number of rows in the output database)
+#'    - runsN_Pid == max(P_id) == runsN_total x scenario_No
+#'    - P_id == a consecutive identification number for each possible SoilWat simulation; used as the ID for the output database
+#'
+#' @aliases it_exp it_site it_Pid
+#' @name indices
+NULL
+
+#' @rdname indices
+#' @return An integer value of the index in loop 1 based on the position
+#'  across loops 1+2b; invariant to \code{include_YN}.
+it_exp <- compiler::cmpfun(function(isim, runN) {
+  stopifnot(sapply(list(isim, runN), is.natural))
+  (isim - 1L) %/% runN + 1L
+})
+#' @rdname indices
+it_exp2 <- function(pid, runN, scN) {
+  stopifnot(sapply(list(pid, runN, scN), is.natural))
+  it_exp(isim = it_sim2(pid, scN), runN)
+}
+
+#' @rdname indices
+#' @return An integer value out of 'runIDs_sites', i.e., the position in loop 2b based on
+#'  position across loops 1+2b; invariant to \code{include_YN}.
+it_site <- compiler::cmpfun(function(isim, runN) {
+  stopifnot(sapply(list(isim, runN), is.natural))
+  (isim - 1L) %% runN + 1L
+})
+#' @rdname indices
+it_site2 <- function(pid, runN, scN) {
+  stopifnot(sapply(list(pid, runN, scN), is.natural))
+  it_site(isim = it_sim2(pid, scN), runN)
+}
+
+#' @rdname indices
+#' @return An integer value of the index across all loops 1+2a+3, invariant
+#'  to \code{include_YN}. A consecutive identification number for each possible SoilWat
+#'  simulation--used as the ID for the output database.
+it_Pid <- compiler::cmpfun(function(isim, runN, sc, scN) {
+  stopifnot(sapply(list(isim, runN, sc, scN), is.natural))
+  (isim - 1L) * scN + sc
+})
+#' @rdname indices
+it_Pid0 <- compiler::cmpfun(function(iexp, isite, runN, sc, scN) {
+  stopifnot(sapply(list(iexp, isite, runN, sc, scN), is.natural))
+  it_Pid(isim = it_sim0(iexp, isite, runN), runN, sc, scN)
+})
+
+#' @rdname indices
+it_sim0 <- compiler::cmpfun(function(iexp, isite, runN) {
+  stopifnot(sapply(list(iexp, isite, runN), is.natural))
+  (iexp - 1L) * runN + isite
+})
+
+#' @rdname indices
+it_sim2 <- function(pid, scN) {
+  stopifnot(sapply(list(pid, scN), is.natural))
+  1L + (pid - 1L) %/% scN
+}
+
+#' @rdname indices
+it_scen2 <- function(pid, scN) {
+  stopifnot(sapply(list(pid, scN), is.natural))
+  1L + (pid - 1L) %% scN
+}

--- a/R/SWSF_OutputDatabase_Functions.R
+++ b/R/SWSF_OutputDatabase_Functions.R
@@ -28,25 +28,24 @@ missing_Pids_outputDB <- compiler::cmpfun(function(Table, dbname) {
   as.integer(mP_ids)
 })
 
-runIDs_from_Pids <- function(dbname, Pids) {
-  resIDs <- -1L
+getIDs_from_db_Pids <- function(dbname, Pids) {
+  res <- data.frame(site_id = -1L, treatment_id = -1L)[-1, ]
 
   if (file.exists(dbname)) {
     con <- DBI::dbConnect(RSQLite::SQLite(), dbname = dbname, flags = RSQLite::SQLITE_RO)
 
     if (DBI::dbExistsTable(con, "runs")) {
-      sql <- paste("SELECT site_id FROM runs WHERE P_id IN (?) ORDER BY site_id")
+      sql <- paste("SELECT site_id, treatment_id FROM runs WHERE P_id IN (?) ORDER BY site_id")
       rs <- RSQLite::dbSendQuery(con, sql)
       RSQLite::dbBind(rs, list(Pids))
-      resIDs <- RSQLite::dbFetch(rs)[, 1]
+      res <- RSQLite::dbFetch(rs)
       RSQLite::dbClearResult(rs)
-      resIDs <- unique(resIDs)
     }
 
     DBI::dbDisconnect(con)
   }
 
-  as.integer(resIDs)
+  res
 }
 
 
@@ -125,9 +124,11 @@ getSiteIds <- compiler::cmpfun(function(con, folderNames) {
   wf_ids[match(folderNames, wf_ids[, "folder"], nomatch = NA), "id"]
 })
 
-local_weatherDirName <- compiler::cmpfun(function(i_sim, scN, runN, runIDs, name.OutputDB) {	# Get name of weather file from output database
+#' Get name of weather file from output database
+local_weatherDirName <- compiler::cmpfun(function(i_sim, runN, scN, name.OutputDB) {
   con <- DBI::dbConnect(RSQLite::SQLite(), dbname = name.OutputDB, flags = RSQLite::SQLITE_RO)
-  temp <- DBI::dbGetQuery(con, paste("SELECT WeatherFolder FROM header WHERE P_id=", it_Pid(i_sim, 1, scN, runN, runIDs)))[1,1]
+  temp <- DBI::dbGetQuery(con, paste("SELECT WeatherFolder FROM header WHERE P_id=",
+    it_Pid(i_sim, runN, 1, scN)))[1, 1]
   DBI::dbDisconnect(con)
   temp
 })
@@ -917,7 +918,13 @@ check_outputDB_completeness <- function(name.OutputDB, name.OutputDBCurrent = NU
       # Update workDB
       if (update_workDB) {
         print("'workDB' is updated with these missing P_id to be prepared for a re-run")
-        missing_runIDs <- runIDs_from_Pids(name.OutputDB, missing_Pids)
+
+        con <- RSQLite::dbConnect(RSQLite::SQLite(), dbname = name.OutputDB,
+          flags = RSQLite::SQLITE_RO)
+        scN <- RSQLite::dbGetQuery(con, "SELECT Max(id) FROM scenario_labels")[1, 1]
+        RSQLite::dbDisconnect(con)
+
+        missing_runIDs <- it_sim2(missing_Pids, scN)
         temp <- dbWork_redo(dir.out, runIDs = missing_runIDs)
       }
     }
@@ -944,10 +951,10 @@ check_outputDB_completeness <- function(name.OutputDB, name.OutputDBCurrent = NU
 
 
   dbOutput_create_Design <- function(con_dbOut, SWRunInformation, Index_RunInformation,
-      site_labels, runsN_master,runIDs_sites, runsN_Pid, runsN_incl, scenario_No, expN,
+      site_labels, runsN_master,runIDs_sites, runsN_Pid, runsN_total, scenario_No, expN,
       create_treatments, create_experimentals, sw_input_treatments, sw_input_treatments_use,
       sw_input_experimentals, climate.conditions, simstartyr, startyr, endyr,
-      counter.digitsN) {
+      digitsN_total) {
 
 		RSQLite::dbGetQuery(con_dbOut, paste("CREATE TABLE",
       "weatherfolders(id INTEGER PRIMARY KEY AUTOINCREMENT, folder TEXT UNIQUE NOT NULL)"))
@@ -1332,7 +1339,7 @@ check_outputDB_completeness <- function(name.OutputDB, name.OutputDBCurrent = NU
 		RSQLite::dbGetQuery(con_dbOut, paste("CREATE TABLE",
 		  "run_labels(id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT UNIQUE NOT NULL);"))
 		temp <- if (useExperimentals) {
-        temp1 <- formatC(SWRunInformation[, "site_id"], width = counter.digitsN,
+        temp1 <- formatC(SWRunInformation[, "site_id"], width = digitsN_total,
           format = "d", flag = "0")
         temp2 <- rep(sw_input_experimentals[, "Label"], each = runsN_master)
         paste(temp1, temp2, site_labels, sep = "_")
@@ -1359,9 +1366,9 @@ check_outputDB_completeness <- function(name.OutputDB, name.OutputDBCurrent = NU
 		  dimnames = list(NULL, c("P_id", "label_id", "site_id", "treatment_id",
 		  "scenario_id"))))
 		db_runs$P_id <- seq_len(runsN_Pid)
-		db_runs$label_id <- rep(seq_len(runsN_incl), each = scenario_No)
+		db_runs$label_id <- rep(seq_len(runsN_total), each = scenario_No)
 		db_runs$site_id <- rep(rep(SWRunInformation$site_id, times = max(expN, 1L)), each = scenario_No)
-		db_runs$scenario_id <- rep(seq_len(scenario_No), times = runsN_incl)
+		db_runs$scenario_id <- rep(seq_len(scenario_No), times = runsN_total)
 
     temp <- if (useExperimentals) {
         as.vector(matrix(data = exp_start_rows, nrow = runsN_master,
@@ -2068,13 +2075,13 @@ check_outputDB_completeness <- function(name.OutputDB, name.OutputDBCurrent = NU
 	}
 
 
-#' @section: NOTE: Do not change the design of the output database without adjusting the iterator
+#' @section: NOTE: Do not change the design of the output database without adjusting the index
 #'   functions 'it_Pid', 'it_exp', and 'it_site' (see part 4)
 make_dbOutput <- function(name.OutputDB, SWRunInformation, Index_RunInformation,
-    site_labels, runsN_master, runIDs_sites, runsN_Pid, runsN_incl, scenario_No, expN,
+    site_labels, runsN_master, runIDs_sites, runsN_Pid, runsN_total, scenario_No, expN,
     create_treatments, create_experimentals, sw_input_treatments, sw_input_treatments_use,
     sw_input_experimentals, climate.conditions, simstartyr, startyr, endyr,
-    counter.digitsN, aon, daily_no, daily_lyr_agg, output_aggregate_daily, SoilLayer_MaxNo,
+    digitsN_total, aon, daily_no, daily_lyr_agg, output_aggregate_daily, SoilLayer_MaxNo,
     SWPcrit_MPa, Tmin_crit_C, Tmax_crit_C, Tmean_crit_C, bin.prcpSizes,
     bin.prcpfreeDurations, DegreeDayBase, st_mo, no.species_regeneration,
     param.species_regeneration, do_clean) {
@@ -2091,10 +2098,10 @@ make_dbOutput <- function(name.OutputDB, SWRunInformation, Index_RunInformation,
     return(n_tables)
 
   dbOutput_create_Design(con_dbOut, SWRunInformation, Index_RunInformation,
-    site_labels, runsN_master, runIDs_sites, runsN_Pid, runsN_incl, scenario_No, expN,
+    site_labels, runsN_master, runIDs_sites, runsN_Pid, runsN_total, scenario_No, expN,
     create_treatments, create_experimentals, sw_input_treatments, sw_input_treatments_use,
     sw_input_experimentals, climate.conditions, simstartyr, startyr, endyr,
-    counter.digitsN)
+    digitsN_total)
 
   dbOverallColumns <- dbOutput_create_OverallAggregationTable(con_dbOut, aon,
     daily_lyr_agg, SoilLayer_MaxNo, SWPcrit_MPa, Tmin_crit_C, Tmax_crit_C, Tmean_crit_C,

--- a/R/SWSF_dbWork.R
+++ b/R/SWSF_dbWork.R
@@ -1,28 +1,59 @@
 ########################
 #------ dbWork functions
 
+add_dbWork_index <- function(con) {
+  prev_indices <- DBI::dbGetQuery(con, "SELECT * FROM sqlite_master WHERE type = 'index'")
+
+  if (NROW(prev_indices) == 0L || !("i_runIDs" %in% prev_indices[, "name"])) {
+    DBI::dbGetQuery(con, paste("CREATE INDEX i_runIDs ON work (runID_total, runID_sites,",
+      "include_YN)"))
+  }
+}
+
+
+
 #' Create a SQLite-database \code{dbWork} to manage runs fo a SWSF simulation project
 #'
 #' @param dbWork A character string. Path to the folder where the database will be created.
-#' @param runIDs An integer vector. Identification numbers of requested runs,
-#'  i.e., all (or a subset) of \code{runIDs_total}, see \code{\link{iterators}}.
+#' @param jobs An integer matrix. Each row corresponds to one call of the simulation
+#'  function \code{do_OneSite}, i.e., \code{runsN_master} x \code{expN}. The columns
+#'  \code{runID_total}, \code{runID_sites}, \code{include_YN} represent a running ID,
+#'  the site_id (row number in master input file), and a flag whether site is being
+#'  simulated or not. See \code{\link{indices}}.
 #' @return Invisibly \code{TRUE}
-create_dbWork <- function(dbWork, runIDs) {
+create_dbWork <- function(dbWork, jobs) {
+  stopifnot(colnames_job_df() %in% dimnames(jobs)[[2]])
+
   con <- RSQLite::dbConnect(RSQLite::SQLite(), dbname = dbWork, flags = RSQLite::SQLITE_RWC)
   DBI::dbExecute(con,
-    paste("CREATE TABLE work(runID INTEGER PRIMARY KEY,",
+    paste("CREATE TABLE work(runID_total INTEGER PRIMARY KEY,",
+    "runID_sites INTEGER NOT NULL, include_YN INTEGER NOT NULL,",
     "completed INTEGER NOT NULL, failed INTEGER NOT NULL, inwork INTEGER NOT NULL,",
     "time_s REAL)"))
 
-  jobs <- matrix(0L, nrow = length(runIDs), ncol = 5,
-    dimnames = list(NULL, c("runID", "completed", "failed", "inwork", "time_s")))
-  jobs[, "runID"] <- sort.int(as.integer(runIDs))
-
   RSQLite::dbWriteTable(con, "work", append = TRUE, value = as.data.frame(jobs))
-  RSQLite::dbDisconnect(con)
+  add_dbWork_index(con)
 
-  invisible(TRUE)
+  RSQLite::dbDisconnect(con)
 }
+
+colnames_job_df <- function() {
+  c("runID_total", "runID_sites", "include_YN", "completed", "failed", "inwork", "time_s")
+}
+
+create_job_df <- function(runsN_master, runsN_total, expN, include_YN) {
+  temp <- colnames_job_df()
+  jobs <- matrix(data = 0L, nrow = runsN_total, ncol = length(temp),
+    dimnames = list(NULL, temp))
+
+  jobs[, "runID_total"] <- seq_len(runsN_total)
+  jobs[, "runID_sites"] <- rep(seq_len(runsN_master), times = max(expN, 1L))
+  temp <- rep(include_YN, times = max(expN, 1L))
+  jobs[temp, "include_YN"] <- 1L
+
+  jobs
+}
+
 
 #' Setup or connect to SQLite-database \code{dbWork} to manage runs fo a SWSF simulation
 #'  project
@@ -33,20 +64,51 @@ create_dbWork <- function(dbWork, runIDs) {
 #'  is created (possibly overwriting an existing one).
 #' @return A logical value indicating success/failure of setting up/connecting to
 #'  \code{dbWork} and initializing with \code{runIDs}.
-setup_dbWork <- function(path, runIDs, continueAfterAbort = FALSE) {
+setup_dbWork <- function(path, runsN_master, runsN_total, expN, include_YN,
+  continueAfterAbort = FALSE) {
+
   dbWork <- file.path(path, "dbWork.sqlite3")
   success <- create <- FALSE
+  jobs <- create_job_df(runsN_master, runsN_total, expN, include_YN)
 
   if (continueAfterAbort) {
     if (file.exists(dbWork)) {
       con <- RSQLite::dbConnect(RSQLite::SQLite(), dbname = dbWork, flags = RSQLite::SQLITE_RW)
-      setup_runIDs <- RSQLite::dbGetQuery(con, "SELECT runID FROM work ORDER BY runID")
 
-      success <- identical(as.integer(setup_runIDs$runID), sort.int(runIDs))
+      if (any(!(dimnames(jobs)[[2]] %in% DBI::dbListFields(con, "work")))) {
+        stop("'setup_dbWork': dbWork is misspecified or outdated; you may fix ",
+          "this by first calling the function 'recreate_dbWork'")
+      }
+      prev_work <- RSQLite::dbGetQuery(con, paste("SELECT runID_total, runID_sites,",
+        "include_YN FROM work ORDER BY runID_total"))
+
+      # check whether same design
+      success <- all(sapply(c("runID_total", "runID_sites"), function(x)
+        identical(prev_work[, x], as.integer(jobs[, x]))))
 
       if (success) {
         # clean-up potentially lingering 'inwork'
         DBI::dbExecute(con, "UPDATE work SET inwork = 0 WHERE inwork > 0")
+
+        # check whether include_YN has been changed and update if necessary
+        if (!identical(prev_work[, "include_YN"], jobs[, "include_YN"])) {
+          # now excluded
+          iwork <- which(prev_work[, "include_YN"] == 1L & jobs[, "include_YN"] == 0L)
+          if (length(iwork) > 0) {
+            rs <- DBI::dbSendStatement(con, paste("UPDATE work SET include_YN = 0",
+              "WHERE runID_total = :x"))
+            DBI::dbBind(rs, param = list(x = iwork))
+          }
+          # now included
+          iwork <- which(prev_work[, "include_YN"] == 0L & jobs[, "include_YN"] == 1L)
+          if (length(iwork) > 0) {
+            rs <- DBI::dbSendStatement(con, paste("UPDATE work SET include_YN = 1",
+              "WHERE runID_total = :x"))
+            DBI::dbBind(rs, param = list(x = iwork))
+          }
+
+          DBI::dbClearResult(rs)
+        }
       }
       RSQLite::dbDisconnect(con)
 
@@ -60,7 +122,7 @@ setup_dbWork <- function(path, runIDs, continueAfterAbort = FALSE) {
   }
 
   if (create) {
-    temp <- create_dbWork(dbWork, runIDs)
+    temp <- create_dbWork(dbWork, jobs)
     success <- !inherits(temp, "try-error")
   }
 
@@ -78,11 +140,11 @@ dbWork_todos <- compiler::cmpfun(function(path) {
   stopifnot(file.exists(dbWork))
 
   con <- RSQLite::dbConnect(RSQLite::SQLite(), dbname = dbWork, flags = RSQLite::SQLITE_RO)
-  runIDs_todo <- RSQLite::dbGetQuery(con, paste("SELECT runID FROM work",
-    "WHERE completed = 0 AND inwork = 0 ORDER BY runID"))
+  runIDs_todo <- RSQLite::dbGetQuery(con, paste("SELECT runID_total FROM work ",
+    "WHERE include_YN = 1 AND completed = 0 AND inwork = 0 ORDER BY runID_total"))
   RSQLite::dbDisconnect(con)
 
-  runIDs_todo$runID
+  as.integer(runIDs_todo[, 1])
 })
 
 #' Extract stored execution times of completed runs of a SWSF simulation project
@@ -94,11 +156,11 @@ dbWork_timing <- compiler::cmpfun(function(path) {
   stopifnot(file.exists(dbWork))
 
   con <- RSQLite::dbConnect(RSQLite::SQLite(), dbname = dbWork, flags = RSQLite::SQLITE_RO)
-  times <- RSQLite::dbGetQuery(con, "SELECT time_s FROM work WHERE completed > 0")
+  times <- RSQLite::dbGetQuery(con, paste("SELECT time_s FROM work WHERE include_YN = 1",
+    "AND completed > 0"))
   RSQLite::dbDisconnect(con)
 
-  times$time_s
-})
+  as.numeric(times[, 1])})
 
 
 
@@ -113,7 +175,7 @@ dbWork_redo <- compiler::cmpfun(function(path, runIDs) {
 
     con <- RSQLite::dbConnect(RSQLite::SQLite(), dbname = dbWork, flags = RSQLite::SQLITE_RW)
     rs <- DBI::dbSendStatement(con, paste("UPDATE work SET completed = 0, failed = 0,",
-      "inwork = 0, time_s = 0 WHERE runID = :x"))
+      "inwork = 0, time_s = 0 WHERE include_YN = 1 AND runID_total = :x"))
     DBI::dbBind(rs, param = list(x = runIDs))
     DBI::dbClearResult(rs)
     RSQLite::dbDisconnect(con)
@@ -122,6 +184,99 @@ dbWork_redo <- compiler::cmpfun(function(path, runIDs) {
     TRUE
   }
 })
+
+
+
+
+#' Re-create dbWork based on dbOutput
+#'
+#' @inheritParams create_dbWork
+#' @param name.OutputDB
+#' @return A logical vector indicating success.
+recreate_dbWork <- function(path, name.OutputDB) {
+  if (file.exists(name.OutputDB)) {
+    dbWork <- file.path(path, "dbWork.sqlite3")
+
+    con <- DBI::dbConnect(RSQLite::SQLite(), dbname = name.OutputDB, flags = RSQLite::SQLITE_RO)
+
+    if (!all(sapply(c("runs", "sites"), function(x) DBI::dbExistsTable(con, x)))) {
+      stop("'recreate_dbWork': OutputDB ", shQuote(name.OutputDB), " has ",
+        "incomplete structure; dbWork cannot be recreated from it.")
+    }
+
+    table_runs <- DBI::dbReadTable(con, "runs")
+    table_sites <- DBI::dbReadTable(con, "sites")
+    RSQLite::dbDisconnect(con)
+
+    # Infer design of simulation experiment
+    infer_expN <- max(table_runs[, "treatment_id"])
+    infer_scN <- max(table_runs[, "scenario_id"])
+    infer_runIDs <- it_sim2(table_runs[, "P_id"], infer_scN)
+    infer_runsN_total <- max(infer_runIDs)
+
+    infer_runsN_master <- dim(table_sites)[1]
+    infer_include_YN <- as.logical(table_sites[, "Include_YN"])
+    infer_runsN_sites <- sum(infer_include_YN)
+
+    do_new_dbWork <- TRUE
+
+    if (file.exists(dbWork)) {
+      # If dbWork present, check whether design is current
+      con2 <- DBI::dbConnect(RSQLite::SQLite(), dbname = dbWork, flags = RSQLite::SQLITE_RW)
+      if (DBI::dbExistsTable(con2, "work")) {
+        has_work <- DBI::dbReadTable(con2, "work")
+
+        if (all(c("runID_total", "runID_sites") %in% names(has_work))) {
+          do_new_dbWork <- !(max(has_work[, "runID_total"]) == dim(has_work)[1] &&
+            max(has_work[, "runID_total"]) == infer_runsN_total &&
+            max(has_work[, "runID_sites"]) == infer_runsN_sites)
+        }
+      }
+
+      RSQLite::dbDisconnect(con2)
+    }
+
+    if (do_new_dbWork) {
+      # Create new dbWork
+      setup_dbWork(path, runsN_master = infer_runsN_master,
+        runsN_total = infer_runsN_total, expN = infer_expN, include_YN = infer_include_YN)
+
+    } else {
+      if (!identical(as.logical(is_work[, "include_YN"]), infer_include_YN)) {
+        # Update include_YN
+        con2 <- RSQLite::dbConnect(RSQLite::SQLite(), dbname = dbWork, flags = RSQLite::SQLITE_RW)
+        rs <- DBI::dbSendStatement(con2, paste("UPDATE work SET include_YN = :x1",
+          "WHERE runID_total = :x2"))
+        DBI::dbBind(rs, param = list(x1 = infer_include_YN, x2 = infer_runIDs))
+        DBI::dbClearResult(rs)
+        RSQLite::dbDisconnect(con2)
+      }
+    }
+
+    # Update completed
+    con <- DBI::dbConnect(RSQLite::SQLite(), dbname = name.OutputDB, flags = RSQLite::SQLITE_RO)
+    tables <- dbOutput_ListOutputTables(con)
+    # get Pids for which simulation output is in the outputDB
+    has_pids <- lapply(tables, function(x) RSQLite::dbGetQuery(con,
+      paste0("SELECT P_id FROM \"", x, "\""))[, 1])
+    RSQLite::dbDisconnect(con)
+    has_complete_pids <- intersect2(has_pids)
+    has_complete_runIDs <- unique(it_sim2(has_complete_pids, infer_scN))
+
+    if (length(has_complete_pids) > 0) {
+      con2 <- RSQLite::dbConnect(RSQLite::SQLite(), dbname = dbWork, flags = RSQLite::SQLITE_RW)
+      rs <- DBI::dbSendStatement(con2, paste("UPDATE work SET completed = 1, failed = 0,",
+      "inwork = 0, time_s = 0 WHERE runID_total = :x"))
+      DBI::dbBind(rs, param = list(x = has_complete_runIDs))
+      DBI::dbClearResult(rs)
+      RSQLite::dbDisconnect(con2)
+    }
+
+  } else {
+    stop("OutputDB ", shQuote(name.OutputDB), " not found on disk.")
+  }
+}
+
 
 
 #' Check run status
@@ -135,7 +290,7 @@ dbWork_check <- compiler::cmpfun(function(path, runIDs) {
 
     con <- RSQLite::dbConnect(RSQLite::SQLite(), dbname = dbWork, flags = RSQLite::SQLITE_RO)
     rs <- DBI::dbSendStatement(con, paste("SELECT completed, failed, inwork FROM work",
-      "WHERE runID = :x"))
+      "WHERE runID_total = :x"))
     DBI::dbBind(rs, param = list(x = runIDs))
     res <- DBI::dbFetch(rs)
     DBI::dbClearResult(rs)
@@ -154,7 +309,7 @@ dbWork_check <- compiler::cmpfun(function(path, runIDs) {
 #'
 #' @inheritParams create_dbWork
 #' @param runID An integer value. The identification number of the current run,
-#'  i.e., a value out of \code{runIDs_total}, see \code{\link{iterators}}.
+#'  i.e., a value out of \code{runIDs_incl}, see \code{\link{indices}}.
 #' @param status A character string. One of "completed", "failed", "inwork".
 #' @param time_s A numeric value. The execution time in seconds; used if \code{status} is one of
 #'  "completed" and "failed".
@@ -186,7 +341,8 @@ dbWork_update_job <- compiler::cmpfun(function(path, runID, status = c("complete
       print(paste0("'dbWork_update_job': (", runID, "-", status, ") attempt to update"))
 
     lock <- lock_access(lock, verbose)
-    con <- try(RSQLite::dbConnect(RSQLite::SQLite(), dbname = dbWork, flags = RSQLite::SQLITE_RW), silent = TRUE)
+    con <- try(RSQLite::dbConnect(RSQLite::SQLite(), dbname = dbWork,
+      flags = RSQLite::SQLITE_RW), silent = TRUE)
 
     if (inherits(con, "SQLiteConnection")) {
       res <- DBI::dbWithTransaction(con, {
@@ -197,18 +353,18 @@ dbWork_update_job <- compiler::cmpfun(function(path, runID, status = c("complete
 
         temp <- if (status == "completed") {
             DBI::dbExecute(con, paste("UPDATE work SET completed = 1, failed = 0,",
-              "inwork = 0, time_s =", time_s, "WHERE runID =", runID))
+              "inwork = 0, time_s =", time_s, "WHERE runID_total =", runID))
 
           } else if (status == "failed") {
             DBI::dbExecute(con, paste("UPDATE work SET completed = 0, failed = 1,",
-              "inwork = 0, time_s =", time_s, "WHERE runID =", runID))
+              "inwork = 0, time_s =", time_s, "WHERE runID_total =", runID))
 
           } else if (status == "inwork") {
             prev_status <- RSQLite::dbGetQuery(con,
-              paste("SELECT inwork FROM work WHERE runID =", runID))$inwork
+              paste("SELECT inwork FROM work WHERE runID_total =", runID))$inwork
             if (prev_status == 0) {
               DBI::dbExecute(con, paste("UPDATE work SET completed = 0, failed = 0,",
-                "inwork = 1, time_s = 0 WHERE runID =", runID))
+                "inwork = 1, time_s = 0 WHERE runID_total =", runID))
             } else {
               if (verbose)
                 print(paste("'dbWork_update_job':", runID, "is already in work"))

--- a/tests/testthat/test_dbWork.R
+++ b/tests/testthat/test_dbWork.R
@@ -4,7 +4,11 @@ context("dbWork: runIDs organization")
 #setwd("~/Dropbox (Personal)/Work_Stuff/2_Research/Software/GitHub_Projects/SoilWat_R_Wrapper/tests/testthat")
 dbpath <- tempdir()
 flock <- tempfile(pattern = "swsflock", tmpdir = normalizePath(dbpath))
-runIDs <- seq_len(100)
+runsN_master <- 25L
+include_YN <- rep(1, runsN_master)
+include_YN[c(1, 10, 24:25)] <- 0L
+expN <- 4L
+runsN_total <- runsN_master * expN
 #fname_log <- "log_dbWork.txt"
 verbose <- FALSE
 
@@ -57,7 +61,7 @@ parallel::clusterEvalQ(cl, require("RSQLite"))
 test_that("dbWork", {
   # Init
   unlink(flock, recursive = TRUE)
-  expect_true(setup_dbWork(dbpath, runIDs))
+  expect_true(setup_dbWork(dbpath, runsN_master, runsN_total, expN, include_YN))
   expect_identical(dbWork_todos(dbpath), runIDs)
 
   #--- Error due to locked database
@@ -69,7 +73,7 @@ test_that("dbWork", {
 
   #--- No error expected because dbWork is run with file locking
   # Init
-  expect_true(setup_dbWork(dbpath, runIDs))
+  expect_true(setup_dbWork(dbpath, runsN_master, runsN_total, expN, include_YN))
   expect_identical(dbWork_todos(dbpath), runIDs)
   expect_s3_class(pretend_sim(cl, runIDs, dbpath, flock, verbose), "table")
 })

--- a/tests/testthat/test_indices.R
+++ b/tests/testthat/test_indices.R
@@ -1,0 +1,112 @@
+context("Indices")
+
+#--- Inputs
+library("RSQLite")
+
+# Initialization
+expN <- 11L
+runsN_master <- 17L
+runsN_total <- runsN_master * max(expN, 1L)
+runIDs_total <- seq_len(runsN_total)
+scenario_No <- 5L
+
+# isim are elements of runIDs_todo
+runIDs_todo <- list(test0 = integer(0), test1 = 0,
+  test2 = runIDs_total, test3 = runIDs_total[1],
+  test4 = as.integer(c(7, 18, 20, 24, 35, 48, 68, 76, 97, 101, 113, 130, 137, 144, 150,
+  169, 185)))
+
+exp_experiment <- list(test0 = integer(0), test1 = 0,
+  test2 = rep(seq_len(expN), each = runsN_master),
+  test3 = 1L, test4 = as.integer(c(1, 2, 2, 2, 3, 3, 4, 5, 6, 6, 7, 8, 9, 9, 9, 10, 11)))
+
+exp_site <- list(test0 = integer(0), test1 = 0,
+  test2 = rep(seq_len(runsN_master), expN),
+  test3 = 1L, test4 = as.integer(c(7, 1, 3, 7, 1, 14, 17, 8, 12, 16, 11, 11, 1, 8, 14,
+  16, 15)))
+
+add_to_pids <- function(atlast, scN) {
+  lapply(rev(seq_len(scN)), function(x) atlast - x + 1)
+}
+
+exp_pids <- list(test0 = rep(list(integer(0)), scenario_No),
+  test1 = rep(list(0), scenario_No),
+  test2 = add_to_pids(atlast = scenario_No * runIDs_total, scenario_No),
+  test3 = seq_len(scenario_No),
+  test4 = add_to_pids(atlast = c(31, 86, 96, 116, 171, 236, 336, 376, 481, 501, 561, 646,
+    681, 716, 746, 841, 921) + scenario_No - 1, scenario_No))
+
+
+#--- Unit tests
+test_that("SWSF indices", {
+  for (k in seq_along(runIDs_todo)) {
+
+    if (is.natural(runIDs_todo[[k]])) {
+      # Index of experimental treatments (row in experimental design file)
+      expect_equal(it_exp(isim = runIDs_todo[[k]], runN = runsN_master),
+        exp_experiment[[k]], label = names(runIDs_todo)[k])
+      expect_equal(it_exp2(pid = exp_pids[[k]][[1]], runN = runsN_master, scN = scenario_No),
+        exp_experiment[[k]], label = names(runIDs_todo)[k])
+
+      # Index of site_id (row in master input file)
+      expect_equal(it_site(isim = runIDs_todo[[k]], runN = runsN_master),
+        exp_site[[k]], label = names(runIDs_todo)[k])
+      expect_equal(it_site2(pid = exp_pids[[k]][[1]], runN = runsN_master, scN = scenario_No),
+        exp_site[[k]], label = names(runIDs_todo)[k])
+
+      # Index of simulation runs
+      expect_equal(it_sim0(iexp = exp_experiment[[k]], isite = exp_site[[k]],
+        runN = runsN_master), runIDs_todo[[k]], label = names(runIDs_todo)[k])
+      expect_equal(it_sim2(pid = exp_pids[[k]][[1]], scN = scenario_No),
+        runIDs_todo[[k]], label = names(runIDs_todo)[k])
+
+      for (sc in seq_len(scenario_No)) {
+        # Index of P_id (unique id in dbOutput)
+        expect_equal(it_Pid(isim = runIDs_todo[[k]], runN = runsN_master, sc = sc,
+          scN = scenario_No), exp_pids[[k]][[sc]],
+          label = paste(names(runIDs_todo)[k], " - scenario =", sc))
+        expect_equal(it_Pid0(iexp = exp_experiment[[k]], isite = exp_site[[k]],
+          runN = runsN_master, sc = sc, scN = scenario_No), exp_pids[[k]][[sc]],
+          label = paste(names(runIDs_todo)[k], " - scenario =", sc))
+
+        # Index of scenario
+        expect_equal(it_scen2(pid = exp_pids[[k]][[sc]], scN = scenario_No),
+          rep(sc, length(exp_pids[[k]][[sc]])),
+          label = paste(names(runIDs_todo)[k], " - scenario =", sc))
+      }
+
+    } else {
+      # Index of experimental treatments (row in experimental design file)
+      expect_error(it_exp(isim = runIDs_todo[[k]], runN = runsN_master),
+        label = names(runIDs_todo)[k])
+      expect_error(it_exp2(pid = exp_pids[[k]][[1]], runN = runsN_master, scN = scenario_No),
+        label = names(runIDs_todo)[k])
+
+      # Index of site_id (row in master input file)
+      expect_error(it_site(isim = runIDs_todo[[k]], runN = runsN_master),
+        label = names(runIDs_todo)[k])
+      expect_error(it_site2(pid = exp_pids[[k]][[1]], runN = runsN_master, scN = scenario_No),
+        label = names(runIDs_todo)[k])
+
+      # Index of simulation runs
+      expect_error(it_sim0(iexp = exp_experiment[[k]], isite = exp_site[[k]],
+        runN = runsN_master), label = names(runIDs_todo)[k])
+      expect_error(it_sim2(pid = exp_pids[[k]][[1]], scN = scenario_No),
+        label = names(runIDs_todo)[k])
+
+      for (sc in seq_len(scenario_No)) {
+        # Index of P_id (unique id in dbOutput)
+        expect_error(it_Pid(isim = runIDs_todo[[k]], runN = runsN_master, sc = sc,
+          scN = scenario_No), label = paste(names(runIDs_todo)[k], " - scenario =", sc))
+        expect_error(it_Pid0(iexp = exp_experiment[[k]], isite = exp_site[[k]],
+          runN = runsN_master, sc = sc, scN = scenario_No),
+          label = paste(names(runIDs_todo)[k], " - scenario =", sc))
+
+        # Index of scenario
+        expect_error(it_scen2(pid = exp_pids[[k]][[sc]], scN = scenario_No),
+          label = paste(names(runIDs_todo)[k], " - scenario =", sc))
+      }
+
+    }
+  }
+})


### PR DESCRIPTION
- redefine index ‘runIDs_total’ as “consecutive number of all possible (sites x exp) simulations” instead of “consecutive number of (included sites x exp) simulations”

- passes test project 4
- successful execution of large simulation experiment with multiple re-starts